### PR TITLE
Remove Pirsch

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 [![CI Build](https://github.com/JuliaDataScience/JuliaDataScience/workflows/CI/badge.svg)](https://github.com/JuliaDataScience/JuliaDataScience/actions?query=workflow%3ACI+branch%3Amain)
 [![CC BY-NC-SA 4.0][cc-by-nc-sa-shield]][cc-by-nc-sa]
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
-[![Site Analytics](https://img.shields.io/badge/site-analytics-blueviolet)](https://juliadatascience-cn.pirsch.io)
 
 本书的中文译本提供了 [在线阅读版](https://cn.julialang.org/JuliaDataScience/) 和 [PDF离线阅读版](https://cn.julialang.org/JuliaDataScience/juliadatascience.pdf).
 

--- a/src/ci.jl
+++ b/src/ci.jl
@@ -67,9 +67,5 @@ function build()
     write_thanks_page()
     fail_on_error = true
     gen(; fail_on_error)
-    extra_head = """
-        <script defer type="text/javascript" src="https://api.pirsch.io/pirsch.js"
-            id="pirschjs" data-code="fEU9oWaR1EuOsES86aD2guTf1qrDM4Ku"></script>
-        """
-    build_all(; extra_head, fail_on_error)
+    build_all(; fail_on_error)
 end


### PR DESCRIPTION
Pirsch was getting too expensive due to the large amount of monthly visitors that we have. The account is marked for deletion in one week, so you can still watch the analytics at https://juliadatascience-cn.pirsch.io for a few days but then it will probably go offline. I've got a download of the CN analytics; just send me a mail if you want the CSV data.